### PR TITLE
feat: Implement request rate-limiting and context timeout handling in server

### DIFF
--- a/handlers/counter_handler.go
+++ b/handlers/counter_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,11 +12,18 @@ import (
 
 func CounterHandler(srv *server.Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
 		now := time.Now()
 
-		count := srv.RecordRequest()
+		count, err := srv.RecordRequest(ctx)
+		if err != nil {
+			http.Error(w, "Request timed out", http.StatusRequestTimeout)
+			return
+		}
+		
 		fmt.Fprintf(w, "Requests in the last 60 seconds: %d\n", count)
-
 		log.Printf("Time taken to serve request %d: %v\n", count, time.Since(now).Truncate(time.Microsecond))
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -53,15 +54,23 @@ func TestRecordRequest(t *testing.T) {
 	}
 
 	time.Sleep(350 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	count := srv.RecordRequest()
+	count, err := srv.RecordRequest(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if count != 1 {
 		t.Errorf("expected count 1, got %v", count)
 	}
 
 	time.Sleep(350 * time.Millisecond)
 
-	count = srv.RecordRequest()
+	count, err = srv.RecordRequest(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if count != 2 {
 		t.Errorf("expected count 2, got %v", count)
 	}


### PR DESCRIPTION
- Added a semaphore to limit the number of concurrent request processing to 5.
- Implemented context timeout handling in `handleRequest` to cancel long-running requests.
- Ensured each request experiences a 2-second simulated delay in `handleRequest`.
- Refined the context propagation in `RecordRequest` and `handleRequest`.
- Updated test cases `TestRecordRequest` and `TestCleanupOldRequests` to verify the new behavior.

These changes ensure that the server can handle requests efficiently with proper rate-limiting and timeout handling, improving robustness and reliability under load.